### PR TITLE
Add connect_query to database config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Some settings are configurable through app config vars at runtime. Refer to the 
 - `PGBOUNCER_SERVER_RESET_QUERY` Default is empty when pool mode is transaction, and "DISCARD ALL;" when session.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`
 - `PGBOUNCER_QUERY_WAIT_TIMEOUT` Default is 120 seconds, helps when the server is down or the database rejects connections for any reason. If this is disabled, clients will be queued infinitely.
+- `PGBOUNCER_CONNECT_QUERY` Default is ''.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -80,6 +80,4 @@ EOFEOF
   let "n += 1"
 done
 
-cat /app/vendor/pgbouncer/pgbouncer.ini
-
 chmod go-rwx /app/vendor/pgbouncer/*

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -66,8 +66,15 @@ do
 "$DB_USER" "$DB_MD5_PASS"
 EOFEOF
 
+if [ -z "$PGBOUNCER_CONNECT_QUERY" ]
+then
+  CONNECT_QUERY_ARG=""
+else
+  CONNECT_QUERY_ARG="connect_query=$PGBOUNCER_CONNECT_QUERY"
+fi
+
   cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
-$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT connect_query=${PGBOUNCER_CONNECT_QUERY}
+$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT $CONNECT_QUERY_ARG
 EOFEOF
 
   let "n += 1"

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -80,4 +80,6 @@ EOFEOF
   let "n += 1"
 done
 
+cat /app/vendor/pgbouncer/pgbouncer.ini
+
 chmod go-rwx /app/vendor/pgbouncer/*

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -67,7 +67,7 @@ do
 EOFEOF
 
   cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
-$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT
+$CLIENT_DB_NAME= host=$DB_HOST dbname=$DB_NAME port=$DB_PORT connect_query=${PGBOUNCER_CONNECT_QUERY}
 EOFEOF
 
   let "n += 1"


### PR DESCRIPTION
**Summary**
Addresses QUA-63.

This PR adds support for pgbouncer's connect_query option. When setting the CONNECT_QUERY_ARG environment variable, we append connect_query=$PGBOUNCER_CONNECT_QUERY to each line in the db section of pgbouncer.ini

**Testing**
Manually ran `gen-pgbouncer-conf.sh` with both an empty and populated value of the PGBOUNCER_CONNECT_QUERY environment variable to verify that the correct parameter is added the the db config. 